### PR TITLE
Add Xcpc, an Amstrad CPC emulator for Linux and BSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1100,11 +1100,12 @@ See multi-emulators section for "Emma 02 emulator"
 
 ### Amstrad CPC computers
 
-| Emulator                                                                                 | FOSS | License     | Free               | Active             | Recommended        | Emulated systems | Platform   |
-|------------------------------------------------------------------------------------------|------|-------------|--------------------|--------------------|--------------------|------------------|------------|
-| [CaPriCe Forever](https://www.cpc-power.com/cpcarchives/index.php?page=articles&num=445) | :x:  | Proprietary | :heavy_check_mark: | :heavy_check_mark: | :heavy_minus_sign: | Amstrad CPC      | :computer: |
-| [NO$CPC](https://problemkaputt.github.io/)                                               | :x:  | Proprietary | :heavy_check_mark: | :x:                | :heavy_minus_sign: | Amstrad CPC      | :computer: |
-| [WinAPE](http://winape.net/)                                                             | :x:  | Proprietary | :heavy_check_mark: | :x:                | :heavy_minus_sign: | Amstrad CPC      | :computer: |
+| Emulator                                                                                 | FOSS               | License     | Free               | Active             | Recommended        | Emulated systems | Platform        |
+|------------------------------------------------------------------------------------------|--------------------|-------------|--------------------|--------------------|--------------------|------------------|-----------------|
+| [CaPriCe Forever](https://www.cpc-power.com/cpcarchives/index.php?page=articles&num=445) | :x:                | Proprietary | :heavy_check_mark: | :heavy_check_mark: | :heavy_minus_sign: | Amstrad CPC      | :computer:      |
+| [NO$CPC](https://problemkaputt.github.io/)                                               | :x:                | Proprietary | :heavy_check_mark: | :x:                | :heavy_minus_sign: | Amstrad CPC      | :computer:      |
+| [WinAPE](http://winape.net/)                                                             | :x:                | Proprietary | :heavy_check_mark: | :x:                | :heavy_minus_sign: | Amstrad CPC      | :computer:      |
+| [Xcpc](https://www.xcpc-emulator.net/)                                                   | :heavy_check_mark: | GNU GPLv2   | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | Amstrad CPC      | :penguin: :imp: |
 
 ### DOS emulators
 


### PR DESCRIPTION
Hi!

I'm the author of Xcpc. I would like to add Xcpc, my Amstrad CPC emulator for Linux and BSD, to this list. Xcpc is developed since apr. 2001 and is under the GNU General Public License v2

Thank you